### PR TITLE
Create basic docker environment and unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ lib64/
 parts/
 sdist/
 var/
-<<<<<<< HEAD
 wheels/
 pip-wheel-metadata/
 share/python-wheels/
@@ -38,11 +37,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-=======
-*.egg-info/
-.installed.cfg
-*.egg
->>>>>>> init
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -57,24 +51,16 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-<<<<<<< HEAD
 .nox/
-=======
->>>>>>> init
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-<<<<<<< HEAD
 *.cover
 *.py,cover
 .hypothesis/
 .pytest_cache/
-=======
-*,cover
-.hypothesis/
->>>>>>> init
 
 # Translations
 *.mo
@@ -83,11 +69,8 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
-<<<<<<< HEAD
 db.sqlite3
 db.sqlite3-journal
-=======
->>>>>>> init
 
 # Flask stuff:
 instance/
@@ -102,7 +85,6 @@ docs/_build/
 # PyBuilder
 target/
 
-<<<<<<< HEAD
 # Jupyter Notebook
 .ipynb_checkpoints
 
@@ -142,42 +124,10 @@ venv.bak/
 # Spyder project settings
 .spyderproject
 .spyproject
-=======
-# IPython Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# dotenv
-.env
-
-# virtualenv
-venv/
-ENV/
-
-# Spyder project settings
-.spyderproject
->>>>>>> init
 
 # Rope project settings
 .ropeproject
 
-<<<<<<< HEAD
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-=======
 # Mac
 ._*
 .DS_Store
@@ -191,4 +141,3 @@ rsa-key
 tags
 singer-check-tap-data
 state.json
->>>>>>> init

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
+IMAGE ?= integration-scripts
+TAG ?= $(shell git log -1 --format=%h)
+
 lint:
 	pylint --rcfile .pylintrc *.py target_ndjson
 
-.PHONY: lint
+build:
+	docker build -f ops/Dockerfile -t $(IMAGE):$(TAG) .
+
+test: build
+	docker run --rm $(IMAGE):$(TAG) pytest
+
+shell: build
+	docker run -v $(PWD):/home/python -it $(IMAGE):$(TAG) bash
+
+.PHONY: lint build test shell

--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ essentially unpacks each `"RECORD"` log recived, verbatim, and writes to file.
 This target is intended for use in systems that implement their own data
 processing layers.
 
+## Testing
+
+This repository can be tested using `pytest`, with or with out a docker container
+
+### Without Docker
+
+```shell
+pip install -r requirements.txt
+pytest
+```
+
+### With Docker
+
+```shell
+# This Makefile contains handy helper commands for using docker.
+# You can also use the docker commands directly (see Makefile for examples)
+make build test
+```
+
 ---
 
 ## TODO
@@ -20,5 +39,5 @@ processing layers.
 This repository is still a WIP! Next tasks, in no particular order:
 
 - [ ] Type hinting
-- [ ] Unit tests
+- [x] Unit tests
 - [ ] Flatten option?

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.8-slim
+
+WORKDIR /home/python
+
+ADD requirements.txt .
+
+RUN BUILD_DEPS="gcc build-essential" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends git ${BUILD_DEPS} \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apt-get purge -y --auto-remove ${BUILD_DEPS} \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /deps
+RUN git clone https://github.com/singer-io/singer-tools.git
+
+WORKDIR /home/python
+
+ADD . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+singer-python>=5.0.12
+ujson
+pytest
+attrs
+jsonschema
+strict-rfc3339
+terminaltables

--- a/target_ndjson/__init__.py
+++ b/target_ndjson/__init__.py
@@ -55,7 +55,7 @@ def main():
         threading.Thread(target=send_usage_stats).start()
 
     tap_output = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-    state = target.persist_lines(config, tap_output, logger)
+    state = target.TargetNDJSON(config, logger).persist_lines(tap_output)
 
     target.emit_state(state, logger)
     logger.debug('Exiting normally')

--- a/target_ndjson/target.py
+++ b/target_ndjson/target.py
@@ -34,7 +34,7 @@ class TargetNDJSON:
 
     @staticmethod
     def __fpath_for_stream(stream_name, timestamp):
-        return '_'.join([stream_name, timestamp])
+        return '_'.join([stream_name, timestamp]) + '.ndjson'
 
     def process_line(self, obj):
         if 'type' not in obj:

--- a/target_ndjson/target.py
+++ b/target_ndjson/target.py
@@ -6,6 +6,7 @@ non-transformative as possible during the process
 from datetime import datetime
 import sys
 import ujson
+from dataclasses import dataclass, field
 
 from jsonschema.validators import Draft4Validator
 
@@ -20,36 +21,29 @@ def emit_state(state, logger):
         sys.stdout.write(f'{line}\n')
         sys.stdout.flush()
 
-def __fpath_for_stream(stream_name, timestamp):
-    return '_'.join([stream_name, timestamp])
+@dataclass
+class TargetNDJSON:
+    config:         dict
+    logger:         object
+    state:          str = ''
+    schemas:        dict = field(default_factory=dict)
+    key_properties: dict = field(default_factory=dict)
+    _headers:       dict = field(default_factory=dict)
+    validators:     dict = field(default_factory=dict)
+    now:            str  = datetime.now().strftime('%Y%m%dT%H%M%S')
 
-def persist_lines(_config, lines, logger):
-    'Triages and writes the logs lines to physical files on disk'
+    @staticmethod
+    def __fpath_for_stream(stream_name, timestamp):
+        return '_'.join([stream_name, timestamp])
 
-    state = None
-    schemas = {}
-    key_properties = {}
-    _headers = {}
-    validators = {}
-
-    now = datetime.now().strftime('%Y%m%dT%H%M%S')
-
-    # Loop over lines from stdin
-    for line in lines:
-        try:
-            obj = ujson.loads(line)
-            assert isinstance(obj, dict)
-        except (ValueError, AssertionError) as e:
-            logger.error(f'Unable to parse:\n{line}')
-            raise InvalidTapJSON(f'Unable to parse: {e} - {line}')
-
+    def process_line(self, obj):
         if 'type' not in obj:
-            raise Exception(f'Line is missing required key "type": {line}')
+            raise Exception(f'Line is missing required key "type": {obj}')
 
         if obj['type'] == 'RECORD':
             if 'stream' not in obj:
-                raise Exception(f'Line is missing required key "stream": {line}')
-            if obj['stream'] not in schemas:
+                raise Exception(f'Line is missing required key "stream": {obj}')
+            if obj['stream'] not in self.schemas:
                 raise Exception(
                     f'A record for stream {obj["stream"]} was encountered before a '
                     'corresponding schema'
@@ -58,25 +52,39 @@ def persist_lines(_config, lines, logger):
             # Get schema for this record's stream
             # schema = schemas[obj['stream']]
             # Validate record
-            validators[obj['stream']].validate(obj['record'])
+            self.validators[obj['stream']].validate(obj['record'])
             # Write to file
-            with open(__fpath_for_stream(obj['stream'], now), 'a') as ostream:
+            with open(TargetNDJSON.__fpath_for_stream(obj['stream'], self.now), 'a') as ostream:
                 ostream.write(ujson.dumps(obj['record']) + '\n')
 
-            state = None
+            self.state = None
         elif obj['type'] == 'STATE':
-            logger.debug('Setting state to {obj["value"]}')
-            state = obj['value']
+            print('-----------', self.logger)
+            self.logger.debug(f'Setting state to {obj["value"]}')
+            self.state = obj['value']
         elif obj['type'] == 'SCHEMA':
             if 'stream' not in obj:
-                raise Exception(f'Line is missing required key "stream": {line}')
+                raise Exception(f'Line is missing required key "stream": {obj}')
             stream = obj['stream']
-            schemas[stream] = obj['schema']
-            validators[stream] = Draft4Validator(obj['schema'])
+            self.schemas[stream] = obj['schema']
+            self.validators[stream] = Draft4Validator(obj['schema'])
             if 'key_properties' not in obj:
                 raise Exception('key_properties field is required')
-            key_properties[stream] = obj['key_properties']
+            self.key_properties[stream] = obj['key_properties']
         else:
             raise Exception(f'Unknown message type {obj["type"]} in message {obj}')
 
-    return state
+    def persist_lines(self, lines):
+        'Triages and writes the logs lines to physical files on disk'
+
+        # Loop over lines from stdin
+        for line in lines:
+            try:
+                obj = ujson.loads(line)
+                assert isinstance(obj, dict)
+            except (ValueError, AssertionError) as e:
+                self.logger.error(f'Unable to parse:\n{line}')
+                raise InvalidTapJSON(f'Unable to parse: {e} - {line}')
+
+            self.process_line(obj)
+        return self.state

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,63 +1,64 @@
 'Test the target-ndjson module'
 
+import glob
+import os
+
 import singer
 import ujson
 
 from target_ndjson import target
 
+def state_log(updated_at='2020-07-05T00:00:00.000000Z'):
+    return ujson.dumps({
+        'type': 'STATE',
+        'value': {
+            'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': updated_at}}
+        }
+    })
+
+def schema_log(properties: dict, key_properties: list):
+    return ujson.dumps({
+        'type': 'SCHEMA',
+        'stream': 'orders',
+        'schema': {'properties': properties},
+        'key_properties': key_properties
+    })
+
+def record_log(record: dict):
+    return ujson.dumps({
+        'type': 'RECORD',
+        'stream': 'orders',
+        'record': record
+    })
 
 class TestTargetNDJSON:
     'Tests the target-ndjson module'
 
-    def setup_class(self):
-        self.schema_log = {
-            'type': 'SCHEMA',
-            'stream': 'orders',
-            'schema': {
-                'properties': {
-                    'transaction_amount': {'type': ['null', 'string']},
-                    'created_at': {'type': 'string'},
-                    'email': {'type': 'string'}
-                }
-            },
-            'key_properties': ['email']
-        }
-        self.state_logs = [
-            {
-                'type': 'STATE',
-                'value': {
-                    'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': '2020-07-05T00:00:00.000000Z'}}
-                }
-            },
-            {
-                'type': 'STATE',
-                'value': {
-                    'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': '2020-07-30T00:00:00.000000Z'}}
-                }
-            },
-            {
-                'type': 'STATE',
-                'value': {
-                    'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': '2020-08-05T00:00:00.000000Z'}}
-                }
-            }
-        ]
-        self.record_log = {
-            'type': 'RECORD',
-            'stream': 'orders',
-            'record': {
-                'email': 'customer@test.com',
-                'created_at': '2020-07-30T01:50:06.000000Z',
-                'transaction_amount': '12.23'
-            }
-        }
+    def teardown_method(self):
+        for fpath in glob.glob('orders_*.ndjson'):
+            os.remove(fpath)
 
     def test_parse(self):
         config = {
-            "start_date": "2020-01-01",
-            "api_key": "XXX",
-            "shop": "myshop"
+            'start_date': '2020-01-01',
+            'api_key': 'XXX',
+            'shop': 'myshop'
         }
-        json_log_lines = [ujson.dumps(l) for l in [self.schema_log, *self.state_logs, self.record_log]]
+        order_schema = schema_log(
+            {
+                'transaction_amount': {'type': ['null', 'string']},
+                'created_at': {'type': 'string'},
+                'email': {'type': 'string'}
+            },
+            ['email']
+        )
+        order_record = record_log({'transaction_amount': '12.34', 'created_at': '2020-01-01T00:00:00.000000Z', 'email': 'test@mail.com'})
+        expected = '''{"transaction_amount":"12.34","created_at":"2020-01-01T00:00:00.000000Z","email":"test@mail.com"}\n'''
 
-        target.TargetNDJSON(config, singer.get_logger()).persist_lines(json_log_lines)
+        obj = target.TargetNDJSON(config, singer.get_logger())
+        obj.persist_lines([order_schema, state_log(), order_record])
+
+        fpaths = glob.glob('orders_*.ndjson')
+        assert len(fpaths) == 1
+        with open(fpaths[0], 'r') as istream:
+            assert expected == istream.read()

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,9 +1,10 @@
 'Test the target-ndjson module'
 
 import singer
+import ujson
+
 from target_ndjson import target
 
-import ujson
 
 class TestTargetNDJSON:
     'Tests the target-ndjson module'
@@ -14,7 +15,7 @@ class TestTargetNDJSON:
             'stream': 'orders',
             'schema': {
                 'properties': {
-                    'transaction_amount': {'type': [ 'null', 'string' ] },
+                    'transaction_amount': {'type': ['null', 'string']},
                     'created_at': {'type': 'string'},
                     'email': {'type': 'string'}
                 }

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,6 +1,62 @@
 'Test the target-ndjson module'
 
+import singer
 from target_ndjson import target
+
+import ujson
 
 class TestTargetNDJSON:
     'Tests the target-ndjson module'
+
+    def setup_class(self):
+        self.schema_log = {
+            'type': 'SCHEMA',
+            'stream': 'orders',
+            'schema': {
+                'properties': {
+                    'transaction_amount': {'type': [ 'null', 'string' ] },
+                    'created_at': {'type': 'string'},
+                    'email': {'type': 'string'}
+                }
+            },
+            'key_properties': ['email']
+        }
+        self.state_logs = [
+            {
+                'type': 'STATE',
+                'value': {
+                    'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': '2020-07-05T00:00:00.000000Z'}}
+                }
+            },
+            {
+                'type': 'STATE',
+                'value': {
+                    'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': '2020-07-30T00:00:00.000000Z'}}
+                }
+            },
+            {
+                'type': 'STATE',
+                'value': {
+                    'bookmarks': {'currently_sync_stream': 'orders', 'orders': {'updated_at': '2020-08-05T00:00:00.000000Z'}}
+                }
+            }
+        ]
+        self.record_log = {
+            'type': 'RECORD',
+            'stream': 'orders',
+            'record': {
+                'email': 'customer@test.com',
+                'created_at': '2020-07-30T01:50:06.000000Z',
+                'transaction_amount': '12.23'
+            }
+        }
+
+    def test_parse(self):
+        config = {
+            "start_date": "2020-01-01",
+            "api_key": "XXX",
+            "shop": "myshop"
+        }
+        json_log_lines = [ujson.dumps(l) for l in [self.schema_log, *self.state_logs, self.record_log]]
+
+        target.TargetNDJSON(config, singer.get_logger()).persist_lines(json_log_lines)


### PR DESCRIPTION
It's hard to test targets currently, and the only available tools are in
the singer-tools repo. These require working taps to use, so I've gone
ahead and started to create unit tests for the target behaviour

* Dockerfile based on python slim
* requirements file with all dependencies required by singer-tools file
* made a placeholder - 1st basic unit test for parsing tap output
* Makefile with some handy docker/test commands