### PR TITLE
Open files and store in dict for faster access

### DIFF
--- a/target_ndjson/target.py
+++ b/target_ndjson/target.py
@@ -64,7 +64,6 @@ class TargetNDJSON:
 
             self.state = None
         elif obj['type'] == 'STATE':
-            print('-----------', self.logger)
             self.logger.debug(f'Setting state to {obj["value"]}')
             self.state = obj['value']
         elif obj['type'] == 'SCHEMA':

--- a/target_ndjson/target.py
+++ b/target_ndjson/target.py
@@ -30,11 +30,17 @@ class TargetNDJSON:
     key_properties: dict = field(default_factory=dict)
     _headers:       dict = field(default_factory=dict)
     validators:     dict = field(default_factory=dict)
-    now:            str  = datetime.now().strftime('%Y%m%dT%H%M%S')
+    now:            str = datetime.now().strftime('%Y%m%dT%H%M%S')
+    file_streams:   dict = field(default_factory=dict)
 
     @staticmethod
     def __fpath_for_stream(stream_name, timestamp):
         return '_'.join([stream_name, timestamp]) + '.ndjson'
+
+    def ensure_files_closed(self):
+        'Ensures that all output files are closed'
+        for _stream, ostream in self.file_streams.items():
+            ostream.close()
 
     def process_line(self, obj):
         if 'type' not in obj:
@@ -48,14 +54,13 @@ class TargetNDJSON:
                     f'A record for stream {obj["stream"]} was encountered before a '
                     'corresponding schema'
                 )
+            if obj['stream'] not in self.file_streams:
+                self.file_streams[obj['stream']] = open(TargetNDJSON.__fpath_for_stream(obj['stream'], self.now), 'w')
 
-            # Get schema for this record's stream
-            # schema = schemas[obj['stream']]
             # Validate record
             self.validators[obj['stream']].validate(obj['record'])
             # Write to file
-            with open(TargetNDJSON.__fpath_for_stream(obj['stream'], self.now), 'a') as ostream:
-                ostream.write(ujson.dumps(obj['record']) + '\n')
+            self.file_streams[obj['stream']].write(ujson.dumps(obj['record']) + '\n')
 
             self.state = None
         elif obj['type'] == 'STATE':
@@ -86,5 +91,11 @@ class TargetNDJSON:
                 self.logger.error(f'Unable to parse:\n{line}')
                 raise InvalidTapJSON(f'Unable to parse: {e} - {line}')
 
-            self.process_line(obj)
+            try:
+                self.process_line(obj)
+            except Exception as e:
+                self.logger.error('Closing all output files after error: %s', e)
+                self.ensure_files_closed()
+                raise e
+        self.ensure_files_closed()
         return self.state


### PR DESCRIPTION
Tap peformance suffers when opening files in append mode repeatedly. This happens for each individual `RECORD` log line and so is very frequent. I've mocked up a quick time comparison in iPython to demonstrate the amount of overhead this creates.

```python
Python 3.8.5 (default, Aug  2 2020, 15:09:07)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.14.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: def test_reopen(fpath, lines):
   ...:     for l in lines:
   ...:         with open(fpath, 'a') as ostream:
   ...:            ostream.write(l + '\n')
   ...:

In [2]: def test_open_once(fpath, lines):
   ...:     with open(fpath, 'w') as ostream:
   ...:         for l in lines:
   ...:             ostream.write(l + '\n')
   ...:

In [3]: lines = list(map(str, range(0, 100)))

In [5]: %timeit test_reopen('test.txt', lines)
783 µs ± 9.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [4]: %timeit test_open_once('test.txt', lines)
92.7 µs ± 3.7 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

This yields an ~8.5x speed increase when the file contents can be written without re-opening in append mode.
 
The only downside to this approach is that the files must be closed before the process exits, as they are no longer opened and closed by the `with` statement.

## Changes

* Make a dict that holds `stream key -> opened output file` that is accessed in order to write lines to file
* Make helper method to ensure that all files are closed before exiting
