### PR TITLE
Type hinting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,6 +5,8 @@ fail-under=10
 [MESSAGES CONTROL]
 # Allow use of f-string interpolation in log calls
 extension-pkg-whitelist=ujson
+# Allow vertical alignment of variable and type definitions
+bad-whitespace
 
 [BASIC]
 # These are allowable short variable names

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ make build test
 
 This repository is still a WIP! Next tasks, in no particular order:
 
-- [ ] Type hinting
+- [x] Type hinting
 - [x] Unit tests
 - [ ] Flatten option?

--- a/target_ndjson/__init__.py
+++ b/target_ndjson/__init__.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import threading
-import urllib
+import urllib.parse
 import pkg_resources
 
 import singer
@@ -16,7 +16,7 @@ from target_ndjson import target
 
 logger = singer.get_logger()
 
-def send_usage_stats():
+def send_usage_stats() -> None:
     'Send usage stats to singer.io'
     try:
         version = pkg_resources.get_distribution('target-csv').version
@@ -36,7 +36,7 @@ def send_usage_stats():
     except Exception:
         logger.debug('Collection request failed')
 
-def main():
+def main() -> None:
     'Parse command-line arguments and run main process'
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
This adds basic `mypy` type hinting to the target. Mostly this consists of adding `-> None` as the return.

## Changes

- `state` is initialised and treated like a string always, rather than None or string
- added pylintrc ignore rule for bad-whitespace